### PR TITLE
Rename USERNAME and PASSWORD environment variables in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Supported ENV variables:
 - PORT (optional, default 8000)
   The port to run this proxy on
 
-- USERNAME (optional)
+- PROXY_USERNAME (optional)
   Basic Auth username to protect this proxy with
 
-- PASSWORD (optional)
+- PROXY_PASSWORD (optional)
   Basic Auth password to protect this proxy with
 
 - AWS_ACCESS_KEY_ID (optional)


### PR DESCRIPTION
I was wondering about the broken basic auth implementation but then I noticed that `USERNAME` is actually `PROXY_USERNAME` and `PASSWORD` is `PROXY_PASSWORD`.

Another issue related to this is https://github.com/coen-hyde/proxilate/pull/1